### PR TITLE
allow injecting logger as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,27 @@ app
     ctx.log.info(ctx, 'Context');
 
     return 'with-context';
+  });
+```
+
+### Use the logger instance both `Standalone` and inside `Context`
+
+```ts
+import { createPinoLogger } from '@bogeychan/elysia-logger';
+
+const log = createPinoLogger(/* ... */);
+
+app
+  .use(log.into(/* ... */))
+  .onError((ctx) => {
+    log.error(ctx, ctx.error.name);
+    return 'onError';
   })
-  .listen(8080);
+  .get('/', (ctx) => {
+    ctx.log.info(ctx, 'Context');
+
+    throw { message: '1234', name: 'MyError' };
+  });
 ```
 
 Checkout the [examples](./examples) folder on github for further use cases such as the integration of [pino-pretty](https://github.com/pinojs/pino-pretty) for readable console outputs.

--- a/examples/on-error-with-context.ts
+++ b/examples/on-error-with-context.ts
@@ -31,12 +31,13 @@ const log = createPinoLogger({
 });
 
 app
+  .use(log.into()) // Call `into` to use the logger instance in both `ctx` and standalone
   .onError((ctx) => {
     log.error(ctx, ctx.error.name);
     return 'onError';
   })
   .get('/', (ctx) => {
-    log.info(ctx, 'Context');
+    ctx.log.info(ctx, 'Context');
 
     throw { message: '1234', name: 'MyError' };
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,14 @@
-import pino, { Logger } from 'pino';
+import pino from 'pino';
 import Elysia from 'elysia';
 
 import type {
+  Logger,
+  ElysiaLogger,
   LoggerOptions,
   FileLoggerOptions,
-  StreamLoggerOptions
+  StreamLoggerOptions,
+  ElysiaLoggerOptions,
+  StandaloneLoggerOptions
 } from './types';
 
 /**
@@ -31,8 +35,14 @@ export const fileLogger = (options: FileLoggerOptions) => plugin(options);
  * Create a logger instance like the plugin.
  */
 export function createPinoLogger(
-  options: Omit<LoggerOptions, 'customProps'> = {}
-) {
+  options: StandaloneLoggerOptions = {}
+): ElysiaLogger<ReturnType<typeof into>> {
+  const log = createPinoLoggerInternal(options);
+  (log as unknown as ElysiaLogger).into = into.bind(log);
+  return log as unknown as ElysiaLogger<ReturnType<typeof into>>;
+}
+
+function createPinoLoggerInternal(options: StandaloneLoggerOptions) {
   if (!options.level) {
     options.level = 'info';
   }
@@ -48,7 +58,6 @@ export function createPinoLogger(
   const streamOptions = options as StreamLoggerOptions;
 
   if ('file' in options) {
-    // @ts-ignore options.file
     streamOptions.stream = pino.destination(options.file);
     delete (options as Partial<FileLoggerOptions>).file;
   }
@@ -56,20 +65,19 @@ export function createPinoLogger(
   return pino(options, streamOptions.stream!);
 }
 
-function plugin(options: LoggerOptions, pinoLoggerOverride: Logger<Omit<LoggerOptions, "customProps">> | null = null) {
+function into(this: Logger, options: ElysiaLoggerOptions = {}) {
   return new Elysia({
     name: '@bogeychan/elysia-logger'
-  }).derive((ctx) => {
-    let log = pinoLoggerOverride ?? createPinoLogger(options);
-
-    if (typeof options.customProps === 'function') {
-      // @ts-ignore
-      log = log.child(options.customProps(ctx));
-    }
-
-    return { log };
-  });
+  }).derive((ctx) => ({
+    log:
+      typeof options.customProps === 'function'
+        ? this.child(options.customProps(ctx))
+        : this
+  }));
 }
+
+const plugin = (options: LoggerOptions) =>
+  into.bind(createPinoLoggerInternal(options))(options);
 
 export * from './config';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,11 +56,11 @@ export function createPinoLogger(
   return pino(options, streamOptions.stream!);
 }
 
-function plugin(options: LoggerOptions) {
+function plugin(options: LoggerOptions, pinoLoggerOverride: Logger<Omit<LoggerOptions, "customProps">> = null) {
   return new Elysia({
     name: '@bogeychan/elysia-logger'
   }).derive((ctx) => {
-    let log = createPinoLogger(options);
+    let log = pinoLoggerOverride ?? createPinoLogger(options);
 
     if (typeof options.customProps === 'function') {
       // @ts-ignore

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import pino from 'pino';
+import pino, { Logger } from 'pino';
 import Elysia from 'elysia';
 
 import type {
@@ -56,11 +56,11 @@ export function createPinoLogger(
   return pino(options, streamOptions.stream!);
 }
 
-function plugin(options: LoggerOptions, pinoLoggerOverride: Logger<Omit<LoggerOptions, "customProps">> = null) {
+function plugin(options: LoggerOptions, pinoLoggerOverride: Logger<Omit<LoggerOptions, "customProps">> | null = null) {
   return new Elysia({
     name: '@bogeychan/elysia-logger'
   }).derive((ctx) => {
-    let log = pinoLoggerOverride ?? createPinoLogger(options);
+    let log = createPinoLogger(options);
 
     if (typeof options.customProps === 'function') {
       // @ts-ignore

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ function plugin(options: LoggerOptions, pinoLoggerOverride: Logger<Omit<LoggerOp
   return new Elysia({
     name: '@bogeychan/elysia-logger'
   }).derive((ctx) => {
-    let log = createPinoLogger(options);
+    let log = pinoLoggerOverride ?? createPinoLogger(options);
 
     if (typeof options.customProps === 'function') {
       // @ts-ignore

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,30 @@ export type FileLoggerOptions = BaseLoggerOptions & {
  */
 export type LoggerOptions = StreamLoggerOptions | FileLoggerOptions;
 
+export type ElysiaLoggerOptions = Pick<BaseLoggerOptions, 'customProps'>;
+
+export type StandaloneLoggerOptions = Omit<LoggerOptions, 'customProps'>;
+
+export interface ElysiaLogger<E extends Elysia = Elysia> extends Logger {
+  /**
+   * Call `into` to use the logger instance in both `ctx` and standalone
+   *
+   * @example
+   * const log = createPinoLogger(...);
+   * app
+   *  .use(log.into())
+   *  .onError((ctx) => {
+   *     log.error(ctx, ctx.error.name);
+   *     return 'onError';
+   *  })
+   *  .get('/', (ctx) => {
+   *     ctx.log.info(ctx, 'Context');
+   *     throw { message: '1234', name: 'MyError' };
+   *  })
+   */
+  into(options?: ElysiaLoggerOptions): E;
+}
+
 type BaseLoggerOptions = Omit<pino.LoggerOptions, 'level'> & {
   /**
    * One of the supported levels or `silent` to disable logging.
@@ -40,7 +64,7 @@ type BaseLoggerOptions = Omit<pino.LoggerOptions, 'level'> & {
   ) => object;
 };
 
-export type Logger = pino.Logger;
+export type Logger<Options = StandaloneLoggerOptions> = pino.Logger<Options>;
 
 export type InferContext<T extends Elysia> = T extends Elysia<
   infer Path,


### PR DESCRIPTION
Haven't done much testing, just quickly throwing some code in github. Will test more in a bit but basically the idea here is that it'd be nice if we could use the already exported createPinoLogger() fn to create our pino logger prior to the Elysia app startup to to bootstrap logging using the same pino logger instance that our elysia app uses.