### PR TITLE
Replace default elysia import with named import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import pino from 'pino';
-import Elysia from 'elysia';
+import { Elysia } from 'elysia';
 
 import type {
   Logger,


### PR DESCRIPTION
The default import has some weird interactions because elysia exports the cjs build under `node` in package.json

for more info: https://github.com/elysiajs/elysia/issues/399

This patch works as a temporary measure against that bug